### PR TITLE
Return error 403 on GET *.sqlite file

### DIFF
--- a/files/nginx.conf
+++ b/files/nginx.conf
@@ -54,5 +54,9 @@ http {
       fastcgi_read_timeout 600;
       include fastcgi_params;
     }
+
+    location ~* \.sqlite$ {
+      return 403;
+    }
   }
 }


### PR DESCRIPTION
Fix vulnerability: user's database can be downloaded via http://<torrentmonitor_url>/db/tm.sqlite